### PR TITLE
Add launcher_id for plotnft discovery 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,7 @@ tokio = {version = "1.21.2", features = ["rt-multi-thread", "macros", "process",
 tokio-tungstenite = {version = "0.20.0", features = ["rustls-tls-webpki-roots", "rustls"] }
 tokio-rustls = {version = "0.24.1", features = [] }
 uuid = {version= "1.2.2", features=["v4"]}
+
+[profile.release]
+lto = true
+codegen-units = 1

--- a/lite-farmer/src/main.rs
+++ b/lite-farmer/src/main.rs
@@ -65,6 +65,7 @@ async fn main() -> Result<(), Error> {
             fullnode_port,
             fullnode_ssl,
             network,
+            launcher_id,
         } => {
             let output_path = cli
                 .config
@@ -78,6 +79,7 @@ async fn main() -> Result<(), Error> {
                 fullnode_ssl,
                 network,
                 None,
+                launcher_id,
             )
             .await?;
         }

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,14 @@ First generate a config, this will search for PlotNFTs that belong to your keys 
 cargo run --release --bin lite-farmer -- run --release --bin lite-farmer -- -c "/path/to/config/farmer_config.yaml" init -m "MNEMONIC" -f FULLNODE_HOST -p FULLNODE_RPC_PORT -n SELECTED_NETWORK
 ```
 
+Optional parameters for the ssl root and launcher id
+
+```
+cargo run --release --bin lite-farmer -- run --release --bin lite-farmer -- -c "/path/to/config/farmer_config.yaml" init -m "MNEMONIC" -f FULLNODE_HOST -p FULLNODE_RPC_PORT -n SELECTED_NETWORK -s "/chia/mainnet/config/ssl/"  -l "0xLAUNCHER_ID"
+```
+
+Edit the generated configuration by accepting the license and adding your plot_directories
+
 Then Start the Farmer and Harvester:
 
 ```


### PR DESCRIPTION
Adds an optional cli parameter `-l` to use the launcher_id's hex string as a fallback for plot nft discovery.

Adds release profile options for a single codegen-unit with lto.  (before binary size: 18M, build time: 1m 43s; after binary size: 12M, build time: 2m 22s)

Updated readme with optional parameters.


Feel free to suggest changes or close this PR if it is unwanted.